### PR TITLE
Add missing closing bracket.

### DIFF
--- a/clingo-mode.el
+++ b/clingo-mode.el
@@ -348,7 +348,7 @@ Argument OPTIONS Options (possibly empty string) sent to clingo."
   (setq-local clingo-last-options options)
   (clingo-echo-clingo
    (buffer-substring-no-properties region-beginning region-end)
-   options))
+   options)))
 
 ;;;###autoload
 (defun clingo-run-buffer (options)


### PR DESCRIPTION
The latest version of the code in MELPA is inoperable because of a missing bracket which we fix here.